### PR TITLE
Allow config section to be optional

### DIFF
--- a/app/config.rb
+++ b/app/config.rb
@@ -70,7 +70,7 @@ class Config
     config = YAML.load_file(file_path)
 
     @check_interval = self.class.default_check_interval
-    if value = config['config']['check_interval']
+    if config_section = config['config'] && value = config_section['check_interval']
       value = value.to_i
       raise "Check interval cannot be zero" if value == 0
       raise "Check interval cannot be negative" if value < 0


### PR DESCRIPTION
The config section of the configuration yaml file is optional as we have default values.