### PR TITLE
Raise the correct exception when Amcrest unreachable

### DIFF
--- a/app/platforms/amcrest_cam/amcrest_cam_platform.rb
+++ b/app/platforms/amcrest_cam/amcrest_cam_platform.rb
@@ -122,9 +122,9 @@ class AmcrestCamPlatform < Platform
         :use_ssl => uri.scheme == 'https') do |https|
         https.request(request)
       end
-    rescue
+    rescue => exception
       # Failed to connect.
-      return nil
+      raise_current_version_check_error("Failed to get latest Amcrest firmware list: #{exception}")
     end
 
     body_text = response.body


### PR DESCRIPTION
Raise a proper runtime issue exception rather than a programmer-error exception.